### PR TITLE
Auto-labeling: prefix Jetpack module names with [Feature]

### DIFF
--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -1,7 +1,7 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
  * Class for photon functionality.
- *
+ * Testing
  * @package automattic/jetpack-image-cdn
  */
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -1,7 +1,7 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
  * Module: Jetpack Carousel
- *
+ *  A change
  * @package automattic/jetpack
  */
 

--- a/projects/plugins/jetpack/modules/photon-cdn.php
+++ b/projects/plugins/jetpack/modules/photon-cdn.php
@@ -3,6 +3,7 @@
  * Module Name: Asset CDN
  * Module Description: Jetpack’s Site Accelerator loads your site faster by optimizing your images and serving your images and static files from our global network of servers.
  * Sort Order: 26
+ * TESTING A CHANGE
  * Recommendation Order: 1
  * First Introduced: 6.6
  * Requires Connection: No


### PR DESCRIPTION
In order to standardize labels across tools and repos, let's prefix our different module labels with "[Feature]".<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

